### PR TITLE
Run ShellCheck on all files

### DIFF
--- a/interactive/interactive.bash
+++ b/interactive/interactive.bash
@@ -1,22 +1,20 @@
 _zblocal_i_interactive=
 
 function _zblocal_f_loginteractive {
-    local inc fmt
+    local inc fmt=n/a
     inc="${2:-0}"
-    if [[ $inc -gt 0 ]]; then
+    if (( inc > 0 )); then
         fmt=yes
     elif [[ -n "${2:-}" ]]; then
         fmt=no
-    else
-        fmt=n/a
     fi
-    printf "%-30s %s\n" "${1:-}:" $fmt
-    _zblocal_i_interactive=$(( $_zblocal_i_interactive + $inc ))
+    printf "%-30s %s\n" "${1:-}:" "$fmt"
+    _zblocal_i_interactive=$(( _zblocal_i_interactive + inc ))
 }
 
 # Returns: 0: isinteractive, 1: is not, 2: unknown
 function _zblocal_f_detectinteractive {
-    local yes=0 no=0 pid=$$ IFS= cur
+    local pid=$$ IFS=
     if [[ -n "${SSH_TTY:-}" ]]; then
         _zblocal_f_loginteractive "ssh-supplied tty" 1
     elif [[ -n "${SSH_CONNECTION:-}" ]]; then
@@ -37,41 +35,41 @@ function _zblocal_f_detectinteractive {
         _zblocal_f_loginteractive "PS1 is set" 1
     fi
 
-    if [[ $- == *i* ]]; then
+    if [[ "$-" == *i* ]]; then
         _zblocal_f_loginteractive "-i on or forced" 1
     else
         _zblocal_f_loginteractive "-i on or forced" 0
     fi
 
-    if [[ $- == *s* ]]; then
+    if [[ "$-" == *s* ]]; then
         _zblocal_f_loginteractive "-s on or forced" 1
     else
         _zblocal_f_loginteractive "-s on or forced" 0
     fi
 
-    if [[ $0 =~ notty ]]; then
+    if [[ "$0" == *notty* ]]; then
         _zblocal_f_loginteractive "\$0 doesn't say notty" 0
     else
         _zblocal_f_loginteractive "\$0 doesn't say notty" 1
     fi
 
-    if [[ $0 =~ ^[-] ]]; then
+    if [[ "$0" == -* ]]; then
         _zblocal_f_loginteractive "\$0 starts with dash" 1
     else
         _zblocal_f_loginteractive "\$0 starts with dash" 1
     fi
 
-    if [[ -f /proc/$pid/cmdline ]]; then
-        cur=
-        while read cur; do
-            if [[ $cur =~ notty ]]; then
+    if [[ -f "/proc/${pid}/cmdline" ]]; then
+        local line seen_notty=
+        while read -r line; do
+            if [[ "$line" == *notty* ]]; then
                 _zblocal_f_loginteractive "cmdline doesn't say notty" 0
-                cur=$'\r' # Will never be in that file, probz.
+                seen_notty=1
                 break
             fi
-        done </proc/$pid/cmdline
+        done <"/proc/${pid}/cmdline"
 
-        if [[ $cur != $'\r' ]]; then
+        if [[ -n "$seen_notty" ]]; then
              _zblocal_f_loginteractive "cmdline doesn't say notty" 1
         fi
     else
@@ -85,11 +83,12 @@ function _zblocal_f_detectinteractive {
         _zblocal_f_loginteractive "Running in a login shell" 0
     fi
 
-    for cur in 0STDIN 1STDOUT 2STDERR; do
-        if [[ -t "${cur:0:1}" ]]; then
-            _zblocal_f_loginteractive "${cur:1} is a tty" 1
+    local descriptors=(STDIN STDOUT STDERR)
+    for cur in "${!descriptors[@]}"; do
+        if [[ -t "$cur" ]]; then
+            _zblocal_f_loginteractive "${descriptors[cur]} is a tty" 1
         else
-            _zblocal_f_loginteractive "${cur:1} is a tty" 0
+            _zblocal_f_loginteractive "${descriptors[cur]}} is a tty" 0
         fi
     done
 }
@@ -98,9 +97,8 @@ function _zblocal_f_detectinteractive {
 # the current shell being interactive. Returns true if so. 
 function isinteractive {
     if [[ -z "$_zblocal_i_interactive" ]]; then
-        printf "Checking terminal interactivity..."
+        echo "Checking terminal interactivity..."
         _zblocal_f_detectinteractive
     fi
-    [[ $_zblocal_i_interactive -gt 0 ]]
-    return $?
+    (( _zblocal_i_interactive > 0 ))
 }

--- a/range/range.bash
+++ b/range/range.bash
@@ -30,8 +30,7 @@ function range {
 	if [[ -n "${3:-}" ]]; then
 		_zblocal_f_rangeoutput "$@"
 	else
-		local from to range elt
-		declare -a rv # Local by default
+		local from to range rv=()
 		
 		from="${1:-}"
 		if [[ "${from}" =~ ^(.+)[.][.](.+)$ ]]; then
@@ -46,7 +45,7 @@ function range {
 		fi
 
 		range="{${from#\{}..${to%\}}}"
-		eval "for elt in $range;"' do rv+=("$elt"); done'
+		eval "local elt; for elt in ${range};"' do rv+=("${elt}"); done'
 
 		if [[ "${rv[0]}" == "$range" ]]; then
 			_zblocal_f_errorf "Could not calculate range '${range}'. Arguments: '${1:-}', '${2:-}'."
@@ -67,9 +66,7 @@ function rangeifs {
 }
 
 function rangefunc {
-	declare -F "${1:-}" > /dev/null
-
-	if [[ $? -gt 0 ]]; then
+	if ! declare -F "${1:-}" > /dev/null; then
 		_zblocal_f_errorf "Requires a function argument; '${1:-}' is not a function."
 		return 1
 	else
@@ -85,7 +82,7 @@ function _zblocal_f_rangeoutput {
 		echo "$*"
 	elif [[ -n "${_zblocal_usefunc:-}" ]]; then
 		for arg; do
-			$_zblocal_usefunc "$arg"
+			"$_zblocal_usefunc" "$arg"
 		done
 	else
 		echo "$@"

--- a/substr/benchmark.sh
+++ b/substr/benchmark.sh
@@ -2,26 +2,21 @@
 
 set -euo pipefail
 
-. ./substr.bash
+# shellcheck disable=SC1091
+source substr.bash
 
-test_start="${2:-}"
-test_end="${3:-}"
-iterations=30000
 str="MoNXZZwU+JPK/nyZgnz/8P4XknxjZREZd5tSb1avuY2n1F1M5a5eKN6hpBaNciHT9OCNQngLaVMs88aUmqq0GvN2/Sxx8Scv+7RHWpul1l+zfc2GEcoPLSTAX8aNIDkaqLrVlQo="
 # str="MoNXZZwU+JPKanyZgnza8P4XknxjZREZd5tSb1avuY2n1F1M5a5eKN6hpBaNciHT9OCNQngLaVMs88aUmqq0GvN2aSxx8Scv+7RHWpul1l+zfc2GEcoPLSTAX8aNIDkaqLrVlQo="
 
 exec 3>&1
 exec 3> /dev/null
 
-
 run_test() {
 	test_start="${1:?Start is required}"
 	test_end="${2:?End is required}"
 	iterations="${3:?Iterations is required}"
-	count=0
-	while [ $count -lt $iterations ]; do
-	    count=$(( $count + 1 ))
-	    substr "$str" $test_start $test_end >&3
+	for (( count=0; count < iterations; ++count )); do
+	    substr "$str" "$test_start" "$test_end" >&3
 	done
 }
 
@@ -29,17 +24,12 @@ run_control() {
 	test_start="${1:?Start is required}"
 	test_end="${2:?End is required}"
 	iterations="${3:?Iterations is required}"
-	count=0
-	while [ $count -lt $iterations ]; do
-	    count=$(( $count + 1 ))
+	for (( count=0; count < iterations; ++count )); do
 	    echo "${str:$test_start:$test_end}" >&3
 	done
 }
 
-
-
-
-echo "Testing with ${3:?Iterations is required} iterations"
+echo "Testing \${str:${1}:${2}} with ${3:?Iterations is required} iterations"
 echo "Control:"
 time ( run_control "$@" )
 echo

--- a/substr/substr.bash
+++ b/substr/substr.bash
@@ -1,11 +1,13 @@
-_zb_substr() {
-    $_zb_local_polyfill input="${1:-}"
-    $_zb_local_polyfill len="${#input}"
-    $_zb_local_polyfill start="${2:-}"
-    $_zb_local_polyfill end="${3:-0}"
+# shellcheck disable=SC2034,SC2154
 
-    if [ "$start" -ge 0 ]; then
-        case $start in
+_zb_substr() {
+    "$_zb_local_polyfill" input="${1:-}"
+    "$_zb_local_polyfill" len="${#input}"
+    "$_zb_local_polyfill" start="${2:-}"
+    "$_zb_local_polyfill" end="${3:-0}"
+
+    if (( start >= 0 )); then
+        case "$start" in
             0*)
                 echo 'Usage: substr string start offset; start and offset must be numbers, start must be positive.' >&2
                 return 127 ;; 
@@ -15,7 +17,7 @@ _zb_substr() {
         return 127
     fi
 
-    if [ "$end" -eq $end ]; then
+    if (( end == end )); then
         # if [ $_zb_has_native ]; then
         #     printf %s "${input:$start:$end}"
         #     return $?
@@ -23,11 +25,11 @@ _zb_substr() {
         # If $end > len(input): end was negative and ended up before start.
         # If $end < 0: end was positive and beyond the end of the string.
         # Otherwise, it's in the string somewhere; compute the offset from the end.
-        case $end in
+        case "$end" in
             # A zero offset is kinda pointless, but you can do it if you want.
             0) ;;
             [1-9]*) end=$(( len < start + end ? 0 : len - start - end )) ;; 
-            [\-]*) end=$(( end * -1 )) ;;
+            -*) end=$(( end * -1 )) ;;
             *) 
                 echo 'Usage: substr string start offset; start and offset must be numbers, start must be positive.' >&2
                 return 127 ;;
@@ -37,24 +39,22 @@ _zb_substr() {
         return 127
     fi
 
-    while [ $start -gt 100 ]; do
-        eval "input=\"\${input#$_zb_nullcache_100}\""
+    while (( start > 100 )); do
+        eval "input=\"\${input#${_zb_nullcache_100}}\""
         start=$(( start - 100 ))
     done
 
     eval "start=\"\$_zb_nullcache_${start}\""
-    eval "input=\"\${input#$start}\""
+    eval "input=\"\${input#${start}}\""
 
-    if [ $end -gt 100 ]; then
-        eval "input=\"\${input%%$_zb_nullcache_100}\""
+    if ((  end > 100 )); then
+        eval "input=\"\${input%%${_zb_nullcache_100}}\""
         end=$(( end % 100 ))
     fi
 
     eval "end=\"\$_zb_nullcache_$end\""
     eval "input=\"\${input%$end}\""
     printf %s "$input"
-
-    return
 }
 
 _zb_setup() {
@@ -65,11 +65,9 @@ _zb_setup() {
     # Gotta use a subshell here since dash quits on a parse-failing eval.
     # Fortunately, it's the only subshell used and doesn't execute another
     # program.
-    if ( a="${_zb_local_polyfill:1:1}"; false ) >/dev/null 2>&1; then
-        true
-    else
-        $_zb_local_polyfill _zb_nullcache_size=""
-        while [ "${#_zb_nullcache_size}" -le 100 ]; do
+    if ! ( a="${_zb_local_polyfill:1:1}"; false ) >/dev/null 2>&1; then
+        "$_zb_local_polyfill" _zb_nullcache_size=""
+        while (( ${#_zb_nullcache_size} <= 100 )); do
             eval "_zb_nullcache_${#_zb_nullcache_size}='${_zb_nullcache_size}'"
             _zb_nullcache_size="${_zb_nullcache_size}?"
         done


### PR DESCRIPTION
`shellcheck --shell=bash $(find * -name …*sh)` now passes.

Made a few other small tweaks (e.g. consistently quoting variables, using `(( ... ))` where appropriate).

One caveat: `substr.bash` appears to be trying to support other shells in addition to bash, which I haven't verified.